### PR TITLE
Crude postexecute and prexecute implementation for issue #19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,12 @@ RUN apk upgrade --update && \
     mkdir -p /etc/volumerize /volumerize-cache /opt/volumerize && \
     touch /etc/volumerize/remove-all-inc-of-but-n-full /etc/volumerize/remove-all-but-n-full /etc/volumerize/startContainers /etc/volumerize/stopContainers \
       /etc/volumerize/backup /etc/volumerize/backupIncremental /etc/volumerize/backupFull /etc/volumerize/restore \
-      /etc/volumerize/periodicBackup /etc/volumerize/verify /etc/volumerize/cleanup /etc/volumerize/remove-older-than /etc/volumerize/cleanCacheLocks && \
+      /etc/volumerize/periodicBackup /etc/volumerize/verify /etc/volumerize/cleanup /etc/volumerize/remove-older-than /etc/volumerize/cleanCacheLocks \
+      /etc/volumerize/postexecute /etc/volumerize/prexecute && \
     chmod +x /etc/volumerize/remove-all-inc-of-but-n-full /etc/volumerize/remove-all-but-n-full /etc/volumerize/startContainers /etc/volumerize/stopContainers \
       /etc/volumerize/backup /etc/volumerize/backupIncremental /etc/volumerize/backupFull /etc/volumerize/restore \
-      /etc/volumerize/periodicBackup /etc/volumerize/verify /etc/volumerize/cleanup /etc/volumerize/remove-older-than /etc/volumerize/cleanCacheLocks && \
+      /etc/volumerize/periodicBackup /etc/volumerize/verify /etc/volumerize/cleanup /etc/volumerize/remove-older-than /etc/volumerize/cleanCacheLocks \
+      /etc/volumerize/postexecute /etc/volumerize/prexecute && \
     # Install Jobber
     export JOBBER_HOME=/tmp/jobber && \
     export JOBBER_LIB=$JOBBER_HOME/lib && \

--- a/README.md
+++ b/README.md
@@ -405,6 +405,14 @@ $ docker run -d \
 
 > Will enforce a full backup after seven days.
 
+# Post scripts and pre scripts
+
+If you mount a folder in `/prexecute` containing `.sh` files, they will be executed in alphabetical order before the backup and after the docker stop process.
+
+If you mount a folder in `/postexecute` containing `.sh` files, they will be executed in alphabetical order after the backup and before the docker start process.
+
+In this scripts the global variable `BACKUP_TYPE` contains the type of backup or restore, so it will contain one of this options `backup, backupIncremental, backupFull or restore` so you can customize your scripts to do one thing or another depending of the type of backup or if its a restore.
+
 # Container Scripts
 
 This image creates at container startup some convenience scripts.
@@ -421,6 +429,8 @@ This image creates at container startup some convenience scripts.
 | stopContainers | Stops the specified Docker containers |
 | remove-older-than | Delete older backups |
 | cleanCacheLocks | Cleanup of old Cache locks. |
+| prexecute | Execute all .sh files in /prexecute folder. |
+| postexecute | Execute all .sh files in /postexecute folder. |
 
 Example triggering script inside running container:
 

--- a/imagescripts/create_scripts.sh
+++ b/imagescripts/create_scripts.sh
@@ -8,13 +8,48 @@ source $CUR_DIR/base.sh
 
 readonly PARAMETER_PROXY='$@'
 
+cat > ${VOLUMERIZE_SCRIPT_DIR}/prexecute << '_EOF_'
+#!/bin/bash
+
+set -o errexit
+
+if [ -d "/prexecute" ]; then
+    for f in /prexecute/*; do
+        case "$f" in
+            *.sh) echo "running $f"; . "$f" ;;
+            *)    echo "ignoring $f" ;;
+        esac
+        echo
+    done
+fi
+_EOF_
+
+cat > ${VOLUMERIZE_SCRIPT_DIR}/postexecute << '_EOF_'
+#!/bin/bash
+
+set -o errexit
+
+if [ -d "/postexecute" ]; then
+    for f in /postexecute/*; do
+        case "$f" in
+            *.sh) echo "running $f"; . "$f" ;;
+            *)    echo "ignoring $f" ;;
+        esac
+        echo
+    done
+fi
+_EOF_
+
+
 cat > ${VOLUMERIZE_SCRIPT_DIR}/backup <<_EOF_
 #!/bin/bash
 
 set -o errexit
 
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
+source ${VOLUMERIZE_SCRIPT_DIR}/prexecute
 ${DUPLICITY_COMMAND} ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET}
+source ${VOLUMERIZE_SCRIPT_DIR}/postexecute
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 _EOF_
 
@@ -24,7 +59,9 @@ cat > ${VOLUMERIZE_SCRIPT_DIR}/backupIncremental <<_EOF_
 set -o errexit
 
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
+source ${VOLUMERIZE_SCRIPT_DIR}/prexecute
 ${DUPLICITY_COMMAND} incremental ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET}
+source ${VOLUMERIZE_SCRIPT_DIR}/postexecute
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 _EOF_
 
@@ -34,7 +71,9 @@ cat > ${VOLUMERIZE_SCRIPT_DIR}/backupFull <<_EOF_
 set -o errexit
 
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
+source ${VOLUMERIZE_SCRIPT_DIR}/prexecute
 ${DUPLICITY_COMMAND} full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET}
+source ${VOLUMERIZE_SCRIPT_DIR}/postexecute
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 _EOF_
 
@@ -44,7 +83,9 @@ cat > ${VOLUMERIZE_SCRIPT_DIR}/restore <<_EOF_
 set -o errexit
 
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
+source ${VOLUMERIZE_SCRIPT_DIR}/prexecute
 ${DUPLICITY_COMMAND} restore --force ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET} ${VOLUMERIZE_SOURCE}
+source ${VOLUMERIZE_SCRIPT_DIR}/postexecute
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 _EOF_
 

--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -47,5 +47,6 @@ if [ "$1" = 'volumerize' ]; then
   pipeEnvironmentVariables
   exec jobberd
 else
+  export BACKUP_TYPE=$@
   exec "$@"
 fi


### PR DESCRIPTION
A quick implementation for the issue #19 , will need more refinement to check edge cases, i didn't tested what happens if one of the scripts fails. Also the script execution order is hardcoded so it looks like

- Stop container
- Execute prescripts
- Do action
- Execute post scripts
- Start container

So, maybe someone will need to execute a script before and after the container step and thats not contemplated in this implementation.

Also i wrote a quick documentation for the Readme, but some work will require to make it look a little bit more professional, also its missing an example of how to use it, or some example scripts, like how this would work to make a mysql backup.

This fix as it is covers my necessity, but if required i can refinate it with the mentioned issues.