### PR TITLE
Multivolume independent backups

### DIFF
--- a/imagescripts/base.sh
+++ b/imagescripts/base.sh
@@ -13,7 +13,7 @@ DUPLICITY_TARGET=${VOLUMERIZE_TARGET}
 DUPLICITY_MODE=""
 
 function resolveOptions() {
-  DUPLICITY_OPTIONS="--allow-source-mismatch --archive-dir=${VOLUMERIZE_CACHE}"
+  DUPLICITY_OPTIONS="--allow-source-mismatch"
   if [ -n "${VOLUMERIZE_DUPLICITY_OPTIONS}" ]; then
     DUPLICITY_OPTIONS=$DUPLICITY_OPTIONS" "${VOLUMERIZE_DUPLICITY_OPTIONS}
   fi

--- a/imagescripts/create_scripts.sh
+++ b/imagescripts/create_scripts.sh
@@ -46,11 +46,31 @@ set -o errexit
 
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
-${DUPLICITY_COMMAND} ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET} || true
+_EOF_
+
+env | grep VOLUMERIZE_SOURCE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    sourceName=${lineParts[0]}
+    sourceValue=${lineParts[1]}
+    sourceNameSuffix=${lineParts[0]:17}
+
+    targetName="VOLUMERIZE_TARGET$sourceNameSuffix"
+    targetValue=`echo ${!targetName}`
+
+    cacheName="VOLUMERIZE_CACHE$sourceNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/backup <<_EOF_
+${DUPLICITY_COMMAND} ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${sourceValue} ${targetValue} || true
+_EOF_
+done
+
+cat >> ${VOLUMERIZE_SCRIPT_DIR}/backup <<_EOF_
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 PREPOSTSTRATEGY=/postexecute/backup
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 _EOF_
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/backupIncremental <<_EOF_
 #!/bin/bash
@@ -59,10 +79,30 @@ set -o errexit
 
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
-${DUPLICITY_COMMAND} incremental ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET} || true
+_EOF_
+
+env | grep VOLUMERIZE_SOURCE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    sourceName=${lineParts[0]}
+    sourceValue=${lineParts[1]}
+    sourceNameSuffix=${lineParts[0]:17}
+
+    targetName="VOLUMERIZE_TARGET$sourceNameSuffix"
+    targetValue=`echo ${!targetName}`
+
+    cacheName="VOLUMERIZE_CACHE$sourceNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/backupIncremental <<_EOF_
+${DUPLICITY_COMMAND} incremental ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${sourceValue} ${targetValue} || true
+_EOF_
+done
+
+cat >> ${VOLUMERIZE_SCRIPT_DIR}/backupIncremental <<_EOF_
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 _EOF_
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/backupFull <<_EOF_
 #!/bin/bash
@@ -71,10 +111,30 @@ set -o errexit
 
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
-${DUPLICITY_COMMAND} full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_SOURCE} ${VOLUMERIZE_TARGET} || true
+_EOF_
+
+env | grep VOLUMERIZE_SOURCE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    sourceName=${lineParts[0]}
+    sourceValue=${lineParts[1]}
+    sourceNameSuffix=${lineParts[0]:17}
+
+    targetName="VOLUMERIZE_TARGET$sourceNameSuffix"
+    targetValue=`echo ${!targetName}`
+
+    cacheName="VOLUMERIZE_CACHE$sourceNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/backupFull <<_EOF_
+${DUPLICITY_COMMAND} full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${sourceValue} ${targetValue} || true
+_EOF_
+done
+
+cat >> ${VOLUMERIZE_SCRIPT_DIR}/backupFull <<_EOF_
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 _EOF_
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/restore <<_EOF_
 #!/bin/bash
@@ -83,10 +143,30 @@ set -o errexit
 
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction restore
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers
-${DUPLICITY_COMMAND} restore --force ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET} ${VOLUMERIZE_SOURCE} || true
+_EOF_
+
+env | grep VOLUMERIZE_SOURCE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    sourceName=${lineParts[0]}
+    sourceValue=${lineParts[1]}
+    sourceNameSuffix=${lineParts[0]:17}
+
+    targetName="VOLUMERIZE_TARGET$sourceNameSuffix"
+    targetValue=`echo ${!targetName}`
+
+    cacheName="VOLUMERIZE_CACHE$sourceNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/restore <<_EOF_
+${DUPLICITY_COMMAND} restore --force ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${sourceValue} ${targetValue} || true
+_EOF_
+done
+
+cat >> ${VOLUMERIZE_SCRIPT_DIR}/restore <<_EOF_
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction restore
 _EOF_
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/verify <<_EOF_
 #!/bin/bash
@@ -94,49 +174,134 @@ cat > ${VOLUMERIZE_SCRIPT_DIR}/verify <<_EOF_
 set -o errexit
 
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction verify
-${DUPLICITY_COMMAND} verify --compare-data ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET} ${VOLUMERIZE_SOURCE}
+_EOF_
+
+env | grep VOLUMERIZE_SOURCE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    sourceName=${lineParts[0]}
+    sourceValue=${lineParts[1]}
+    sourceNameSuffix=${lineParts[0]:17}
+
+    targetName="VOLUMERIZE_TARGET$sourceNameSuffix"
+    targetValue=`echo ${!targetName}`
+
+    cacheName="VOLUMERIZE_CACHE$sourceNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/verify <<_EOF_
+${DUPLICITY_COMMAND} verify --compare-data ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${sourceValue} ${targetValue}
+_EOF_
+done
+
+cat >> ${VOLUMERIZE_SCRIPT_DIR}/verify <<_EOF_
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction verify
 _EOF_
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/cleanup <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-exec ${DUPLICITY_COMMAND} cleanup ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET}
 _EOF_
+
+env | grep VOLUMERIZE_TARGET | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    targetName=${lineParts[0]}
+    targetValue=${lineParts[1]}
+    targetNameSuffix=${lineParts[0]:17}
+
+    cacheName="VOLUMERIZE_CACHE$targetNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/cleanup <<_EOF_
+exec ${DUPLICITY_COMMAND} cleanup ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${targetValue}
+_EOF_
+done
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/list <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-exec ${DUPLICITY_COMMAND} collection-status ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET}
 _EOF_
+
+env | grep VOLUMERIZE_TARGET | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    targetName=${lineParts[0]}
+    targetValue=${lineParts[1]}
+    targetNameSuffix=${lineParts[0]:17}
+
+    cacheName="VOLUMERIZE_CACHE$targetNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/list <<_EOF_
+exec ${DUPLICITY_COMMAND} collection-status ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${targetValue}
+_EOF_
+done
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/remove-older-than <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-exec ${DUPLICITY_COMMAND} remove-older-than ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_INCUDES} ${VOLUMERIZE_TARGET}
 _EOF_
+
+env | grep VOLUMERIZE_TARGET | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    targetName=${lineParts[0]}
+    targetValue=${lineParts[1]}
+    targetNameSuffix=${lineParts[0]:17}
+
+    cacheName="VOLUMERIZE_CACHE$targetNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/remove-older-than <<_EOF_
+exec ${DUPLICITY_COMMAND} remove-older-than ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${VOLUMERIZE_INCUDES} ${targetValue}
+_EOF_
+done
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/remove-all-but-n-full <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-exec ${DUPLICITY_COMMAND} remove-all-but-n-full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_TARGET}
 _EOF_
+
+env | grep VOLUMERIZE_TARGET | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    targetName=${lineParts[0]}
+    targetValue=${lineParts[1]}
+    targetNameSuffix=${lineParts[0]:17}
+
+    cacheName="VOLUMERIZE_CACHE$targetNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/remove-all-but-n-full <<_EOF_
+exec ${DUPLICITY_COMMAND} remove-all-but-n-full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${targetValue}
+_EOF_
+done
+
 
 cat > ${VOLUMERIZE_SCRIPT_DIR}/remove-all-inc-of-but-n-full <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-exec ${DUPLICITY_COMMAND} remove-all-inc-of-but-n-full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} ${VOLUMERIZE_TARGET}
 _EOF_
+
+env | grep VOLUMERIZE_TARGET | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    targetName=${lineParts[0]}
+    targetValue=${lineParts[1]}
+    targetNameSuffix=${lineParts[0]:17}
+
+    cacheName="VOLUMERIZE_CACHE$targetNameSuffix"
+    cacheValue=`echo ${!cacheName}`
+
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/remove-all-inc-of-but-n-full <<_EOF_
+exec ${DUPLICITY_COMMAND} remove-all-inc-of-but-n-full ${PARAMETER_PROXY} ${DUPLICITY_OPTIONS} --archive-dir=${cacheValue} ${targetValue}
+_EOF_
+done
+
 
 FILENAME_VARIABLE='$filename'
 
@@ -144,6 +309,14 @@ cat > ${VOLUMERIZE_SCRIPT_DIR}/cleanCacheLocks <<_EOF_
 #!/bin/bash
 
 set -o errexit
-
-find /volumerize-cache/ -maxdepth 2 -type f -name lockfile.lock | while read filename ; do fuser -s ${FILENAME_VARIABLE} || rm -fv ${FILENAME_VARIABLE} ; done
 _EOF_
+
+env | grep VOLUMERIZE_CACHE | while read -r line ; do
+    lineParts=(`echo $line | tr "=" " "`)
+    cacheName=${lineParts[0]}
+    cacheValue=${lineParts[1]}
+    
+    cat >> ${VOLUMERIZE_SCRIPT_DIR}/cleanCacheLocks <<_EOF_
+find ${cacheValue}/ -maxdepth 2 -type f -name lockfile.lock | while read filename ; do fuser -s ${FILENAME_VARIABLE} || rm -fv ${FILENAME_VARIABLE} ; done
+_EOF_
+done

--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -36,7 +36,8 @@ if [ -n "${VOLUMERIZE_DELAYED_START}" ]; then
   sleep ${VOLUMERIZE_DELAYED_START}
 fi
 
-if [ -n "${VOLUMERIZE_SOURCE}" ]; then
+#if [ -n "${VOLUMERIZE_SOURCE}" ]; then
+if [ `env | grep VOLUMERIZE_SOURCE | wc -l` -gt 0 ]; then
   source $CUR_DIR/create_scripts.sh
   source $CUR_DIR/create_jobber.sh
   source $CUR_DIR/create_docker_scripts.sh


### PR DESCRIPTION
This pull request refers to my comment in #29

It allows to have backups of multiple volumes stored independently. I have followed the idea of having multiple variables to indicate multiple sources, targets and caches, you exposed in one comment.

```
docker run -it --rm \
    --name volumerize \
    -v <volume_server_data>:/sourceserver:ro \
    -v <volume_db_data>:/sourcedb:ro \
    -v <volume_backup_server>:/backupserver \
    -v <volume_backup_db>:/backupdb \
    -v <cache_volume_server>:/volumerize-cache-server \
    -v <cache_volume_db>:/volumerize-cache-db \
    -e "VOLUMERIZE_SOURCE_SERVER=/sourceserver" \
    -e "VOLUMERIZE_TARGET_SERVER=file:///backupserver" \
    -e "VOLUMERIZE_CACHE_SERVER=/volumerize-cache-server" \
    -e "VOLUMERIZE_SOURCE_DB=/sourcedb" \
    -e "VOLUMERIZE_TARGET_DB=file:///backupdb" \
    -e "VOLUMERIZE_CACHE_DB=/volumerize-cache-db" \
    blacklabelops/volumerize backup
```

This way, by using the variable `VOLUMERIZE_CONTAINERS`, is required only one container of _volumerize_ to have consistent and independent backups of multiple volumes. The workflow would be:

`stop containers > backup volume 1 > backup volume N > start containers`

For me, this way is far more simple than having multiple instances of volumerize and having scripts to coordinate stopping all containers, backuping and restarting them.