### PR TITLE
exporting DUPLICITY_RETURN_CODE before post backup execution

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -43,5 +43,6 @@ ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 ${VOLUMERIZE_SCRIPT_DIR}/stopContainers.sh
 commandExecution $@
 ${VOLUMERIZE_SCRIPT_DIR}/startContainers.sh
+export DUPLICITY_RETURN_CODE
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 exit $DUPLICITY_RETURN_CODE

--- a/scripts/backupFull
+++ b/scripts/backupFull
@@ -43,5 +43,6 @@ ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers.sh
 commandExecution $@
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers.sh
+export DUPLICITY_RETURN_CODE
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 exit $DUPLICITY_RETURN_CODE

--- a/scripts/backupIncremental
+++ b/scripts/backupIncremental
@@ -43,5 +43,6 @@ ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers.sh
 commandExecution $@
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers.sh
+export DUPLICITY_RETURN_CODE
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 exit $DUPLICITY_RETURN_CODE

--- a/scripts/periodicBackup
+++ b/scripts/periodicBackup
@@ -43,5 +43,6 @@ ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction backup
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers.sh
 commandExecution $@
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers.sh
+export DUPLICITY_RETURN_CODE
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction backup
 exit $DUPLICITY_RETURN_CODE

--- a/scripts/restore
+++ b/scripts/restore
@@ -43,5 +43,6 @@ ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy preAction restore
 source ${VOLUMERIZE_SCRIPT_DIR}/stopContainers.sh
 commandExecution $@
 source ${VOLUMERIZE_SCRIPT_DIR}/startContainers.sh
+export DUPLICITY_RETURN_CODE
 ${VOLUMERIZE_SCRIPT_DIR}/prepoststrategy postAction restore
 exit $DUPLICITY_RETURN_CODE


### PR DESCRIPTION
Hi, 
I wanted to be able to execute a specific action when the backup fails. 

Therefore it would be a good idea to export the DUPLICITY_RETURN_CODE to the bash scripts that are run after the backup. You would then be able to act on the return code and for example push it to prometheus or send an alert email. 

As the repository isn't maintained anymore I suggested to implement the regarding changes myself and send a pull request for others to be able to use it too. 