### PR TITLE
Add python-pexpect to enable pexpect+scp:// urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apk upgrade --update && \
       boto \
       lockfile \
       paramiko \
+      pexpect \
       pycryptopp \
       python-keystoneclient \
       python-swiftclient \


### PR DESCRIPTION
I am using pexpect+scp urls to enable rate limiting on the scp command. This might be handy for someone and i'd also like to switch back on your image, if you include this module in your Dockerfile.

Thanks for this great piece of software!