### PR TITLE
Update google-api-client to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN apk upgrade --update && \
       urllib3 \
       b2 \
       dropbox && \
+    pip install --upgrade google-api-python-client && \
     mkdir -p /etc/volumerize /volumerize-cache /opt/volumerize && \
     curl -fSL "https://code.launchpad.net/duplicity/${DUPLICITY_SERIES}-series/${DUPLICITY_VERSION}/+download/duplicity-${DUPLICITY_VERSION}.tar.gz" -o /tmp/duplicity.tar.gz && \
     export DUPLICITY_SHA=2d048377c839ae56fc2828997c9aa7ba8c339e815e1e2ae738652037508ec276a2c72583687da34408fadd4839011e242b51bc73cca954227fc51db5683c258c && \


### PR DESCRIPTION
This fixes https://github.com/blacklabelops/volumerize/issues/86

I need help to bump the tag on docker hub. I could not find out where to change the config or something like that. Did you change that manually on jenkins or something? Anyway, hope this helps.